### PR TITLE
Refine weight remainder distribution algorithm

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -133,15 +133,22 @@ fn calculate_actual_weights(asset_data: &mut Vec<AssetData>) {
         .iter()
         .fold(0, |acc, x| acc + x.converted_weight.unwrap());
 
-    let mut remainder = u16::MAX - 1311 - adjusted_sum;
+    let remainder = u16::MAX - 1311 - adjusted_sum;
+    let base = remainder / asset_data.len() as u16;
+    let extra = remainder % asset_data.len() as u16;
 
-    while remainder != 0 {
-        for i in asset_data.iter_mut() {
-            i.converted_weight.replace(i.converted_weight.unwrap() + 1);
-            remainder -= 1;
-            if remainder == 0 {
-                break;
-            }
-        }
-    }
+    asset_data.iter_mut().for_each(|asset| {
+        asset
+            .converted_weight
+            .replace(asset.converted_weight.unwrap() + base);
+    });
+
+    asset_data
+        .iter_mut()
+        .take(extra as usize)
+        .for_each(|asset| {
+            asset
+                .converted_weight
+                .replace(asset.converted_weight.unwrap() + 1);
+        });
 }


### PR DESCRIPTION
## Summary
- distribute weight remainder using integer division to calculate base and extra
- apply base to all assets and increment first `extra` entries

## Testing
- `cargo fmt -- --check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a728d0da44832d9a2db17cf565d019