### PR TITLE
Use JOOCE weight constant

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -139,7 +139,7 @@ fn calculate_actual_weights(asset_data: &mut Vec<AssetData>) {
         .iter()
         .fold(0, |acc, x| acc + x.converted_weight.unwrap());
 
-    let remainder = u16::MAX - 1311 - adjusted_sum;
+    let remainder = u16::MAX - JOOCE_INT_WEIGHT - adjusted_sum;
     let base = remainder / asset_data.len() as u16;
     let extra = remainder % asset_data.len() as u16;
 


### PR DESCRIPTION
## Summary
- Replace hardcoded remainder value in `calculate_actual_weights` with `JOOCE_INT_WEIGHT` constant

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a894d4fe10832d9603dd0ce07ca341