### PR TITLE
Initialize Solana mint pubkeys for faster lookups

### DIFF
--- a/src/fetch_data.rs
+++ b/src/fetch_data.rs
@@ -10,7 +10,7 @@ use alloy::{
 use op_alloy_network::{Ethereum, Optimism};
 use solana_client::rpc_client;
 use solana_sdk::pubkey::Pubkey;
-use std::{collections::HashMap, str::FromStr};
+use std::collections::HashMap;
 
 pub async fn get_relative_weight(
     provider: DynProvider<Optimism>,
@@ -80,21 +80,18 @@ pub async fn get_ticker(asset_data: &[AssetData]) -> Vec<String> {
                     ))
                 });
         } else {
-            let mint_address = ADDR_TO_SOL_MINT_ADDR.get(&asset.token_addr).unwrap();
-            let pub_key = solana_sdk::pubkey::Pubkey::from_str(mint_address).unwrap();
-            let pda = mpl_token_metadata::accounts::Metadata::find_pda(&pub_key).0;
+            let mint_pubkey = ADDR_TO_SOL_MINT_ADDR.get(&asset.token_addr).unwrap();
+            let pda = mpl_token_metadata::accounts::Metadata::find_pda(mint_pubkey).0;
             solana_tokens.push(pda);
             solana_indices.push(i);
         }
     }
 
     for (_k, v) in provider_map.into_iter() {
-
         let (indices, _provider, multicall) = v.unwrap();
         let result = multicall.aggregate().await.unwrap();
         for (idx, sym) in indices.iter().zip(result) {
             symbols[*idx] = sym.to_uppercase();
-
         }
     }
     let sol_provider = rpc_client::RpcClient::new(

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -1,7 +1,6 @@
 use alloy::primitives::{Address, U256, address};
-use std::collections::hash_map::HashMap;
-use std::env;
-use std::sync::LazyLock;
+use solana_sdk::pubkey::Pubkey;
+use std::{collections::hash_map::HashMap, env, str::FromStr, sync::LazyLock};
 
 pub const VOTING_CONTRACT_ADDRESS: &str = "0xdD5CB392A549644295862f96f25484a56FB2e6a8";
 pub const INACTIVE_ASSETS: [Address; 1] = [address!("0x576e2bed8f7b46d34016198911cdf9886f78bea7")];
@@ -36,59 +35,59 @@ pub static CHAIN_ID_TO_STRING: LazyLock<HashMap<U256, &str>> = LazyLock::new(|| 
     map
 });
 
-pub static ADDR_TO_SOL_MINT_ADDR: LazyLock<HashMap<Address, &str>> = LazyLock::new(|| {
+pub static ADDR_TO_SOL_MINT_ADDR: LazyLock<HashMap<Address, Pubkey>> = LazyLock::new(|| {
     let mut map = HashMap::new();
     map.insert(
         address!("0x6A851667B20800988c0cE34276F63f86f085BB2c"),
-        "MEW1gQWJ3nEXg2qgERiKu7FAFj79PHvQVREQUzScPP5",
+        Pubkey::from_str("MEW1gQWJ3nEXg2qgERiKu7FAFj79PHvQVREQUzScPP5").unwrap(),
     );
     map.insert(
         address!("0xaf78C51362ee75477Aa11fc660d1955dD34F37B8"),
-        "2qEHjDLDLbuBgRYvsxhc5D6uDWAivNFZGan56P1tpump",
+        Pubkey::from_str("2qEHjDLDLbuBgRYvsxhc5D6uDWAivNFZGan56P1tpump").unwrap(),
     );
     map.insert(
         address!("0xD29E4552ed325ab75A99cC661c280625D5B38cE9"),
-        "9BB6NFEcjBCtnNLFko2FqVQBq8HHM13kCyYcdQbgpump",
+        Pubkey::from_str("9BB6NFEcjBCtnNLFko2FqVQBq8HHM13kCyYcdQbgpump").unwrap(),
     );
     map.insert(
         address!("0xC069D48749327243b699C1B91D22613DC39551e4"),
-        "EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm",
+        Pubkey::from_str("EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm").unwrap(),
     );
     map.insert(
         address!("0xA48F7855a0b3200B1d0CA84c12399171dD456624"),
-        "2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv",
+        Pubkey::from_str("2zMMhcVQEXDtdE6vsFS7S7D5oUodfJHE8vd1gnBouauv").unwrap(),
     );
     map.insert(
         address!("0xf9a337194f9278275Ee28CeFeb58adAdBcB62572"),
-        "7GCihgDB8fe6KNjn2MYtkzZcRjQy3t9GHdC8uHYmW2hr",
+        Pubkey::from_str("7GCihgDB8fe6KNjn2MYtkzZcRjQy3t9GHdC8uHYmW2hr").unwrap(),
     );
     map.insert(
         address!("0x4520A52CfB5daD1a6aeAd5f43C96eD2A9760E77e"),
-        "HeLp6NuQkmYB4pYWo2zYs22mESHXPQYzXbB8n4V98jwC",
+        Pubkey::from_str("HeLp6NuQkmYB4pYWo2zYs22mESHXPQYzXbB8n4V98jwC").unwrap(),
     );
     map.insert(
         address!("0x2107895Cd820573Cdc943dF2A26910945555C29d"),
-        "63LfDmNb3MQ8mw9MtZ2To9bEA2M71kZUUGq5tiJxcqj9",
+        Pubkey::from_str("63LfDmNb3MQ8mw9MtZ2To9bEA2M71kZUUGq5tiJxcqj9").unwrap(),
     );
     map.insert(
         address!("0xf3BC9c7DaA0aeb694c95d65c2FE86137695F2a59"),
-        "ED5nyyWEzpPPiWimP8vYm7sD7TD3LAt3Q3gRTWHzPJBY",
+        Pubkey::from_str("ED5nyyWEzpPPiWimP8vYm7sD7TD3LAt3Q3gRTWHzPJBY").unwrap(),
     );
     map.insert(
         address!("0x75939e0A1Eb2321DBaCcDB2E637DdBa29098Eb16"),
-        "CzLSujWBLFsSjncfkh59rUFqvafWcY5tzedWJSuypump",
+        Pubkey::from_str("CzLSujWBLFsSjncfkh59rUFqvafWcY5tzedWJSuypump").unwrap(),
     );
     map.insert(
         address!("0xDD2DDf33d0936A2A4E8316DFc89F538fCc1fA5b1"),
-        "ukHH6c7mMyiWCf1b9pnWe25TSpkDDt3H5pQZgZ74J82",
+        Pubkey::from_str("ukHH6c7mMyiWCf1b9pnWe25TSpkDDt3H5pQZgZ74J82").unwrap(),
     );
     map.insert(
         address!("0xfFeBa30f39FaA3601911090d5ce7388D719109c9"),
-        "A8C3xuqscfmyLrte3VmTqrAq8kgMASius9AFNANwpump",
+        Pubkey::from_str("A8C3xuqscfmyLrte3VmTqrAq8kgMASius9AFNANwpump").unwrap(),
     );
     map.insert(
         address!("0xa697e272a73744b343528c3bc4702f2565b2f422"),
-        "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263",
+        Pubkey::from_str("DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263").unwrap(),
     );
 
     map


### PR DESCRIPTION
## Summary
- Map asset addresses directly to Solana `Pubkey` values
- Parse Solana mint addresses once during static initialization
- Use pre-parsed mint `Pubkey` in ticker lookup

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a89a0bfff8832dab58a3e1b9dfc062